### PR TITLE
商品詳細表示

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,9 @@ class ApplicationController < ActionController::Base
   private
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up,keys: [:nickname, :family_name, :first_name, :family_name_kana, :first_name_kana, :birth_day])
+    devise_parameter_sanitizer.permit(:sign_up,
+                                      keys: [:nickname, :family_name, :first_name, :family_name_kana, :first_name_kana,
+                                             :birth_day])
   end
 
   def basic_auth
@@ -12,5 +14,4 @@ class ApplicationController < ActionController::Base
       username == ENV['BASIC_AUTH_USER'] && password == ENV['BASIC_AUTH_PASSWORD']
     end
   end
-  
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index, :show, :destroy]
+  before_action :authenticate_user!, except: [:index, :show]
+  before_action :set_item, only: [:show]
 
   def index
     @item = Item.all.order(created_at: :desc)
@@ -18,12 +19,20 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    # @item = Item.new
+    # @order = @item.order
+  end
 
 
   private
 
   def item_params
     params.require(:item).permit(:item_name, :explanation, :category_id, :condition_id, :shipping_id, :prefecture_id, :schedule_id, :price, :image).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,15 +24,14 @@ class ItemsController < ApplicationController
     # @order = @item.order
   end
 
-
   private
 
   def item_params
-    params.require(:item).permit(:item_name, :explanation, :category_id, :condition_id, :shipping_id, :prefecture_id, :schedule_id, :price, :image).merge(user_id: current_user.id)
+    params.require(:item).permit(:item_name, :explanation, :category_id, :condition_id, :shipping_id, :prefecture_id,
+                                 :schedule_id, :price, :image).merge(user_id: current_user.id)
   end
 
   def set_item
     @item = Item.find(params[:id])
   end
-
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -12,8 +12,7 @@ class Category < ActiveHash::Base
     { id: 10, name: 'ハンドメイド' },
     { id: 11, name: 'その他' }
   ]
-  
+
   include ActiveHash::Associations
   has_many :item
-
-  end
+end

--- a/app/models/condition.rb
+++ b/app/models/condition.rb
@@ -8,8 +8,7 @@ class Condition < ActiveHash::Base
     { id: 6, name: '傷や汚れあり' },
     { id: 7, name: '全体的に状態が悪い' }
   ]
-  
+
   include ActiveHash::Associations
   has_many :item
-
-  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,20 +11,20 @@ class Item < ApplicationRecord
   belongs_to :schedule
   has_one_attached :image
 
-  validates :category_id, numericality: { other_than: 1 , message: "can't be blank"}
-  validates :condition_id, numericality: { other_than: 1 , message: "can't be blank"}
-  validates :shipping_id, numericality: { other_than: 1 , message: "can't be blank"}
-  validates :prefecture_id, numericality: { other_than: 1 , message: "can't be blank"}
-  validates :schedule_id, numericality: { other_than: 1 , message: "can't be blank"}
+  validates :category_id, numericality: { other_than: 1, message: "can't be blank" }
+  validates :condition_id, numericality: { other_than: 1, message: "can't be blank" }
+  validates :shipping_id, numericality: { other_than: 1, message: "can't be blank" }
+  validates :prefecture_id, numericality: { other_than: 1, message: "can't be blank" }
+  validates :schedule_id, numericality: { other_than: 1, message: "can't be blank" }
   validates :item_name, presence: true
   validates :explanation, presence: true
 
   with_options presence: true, format: { with: /\A[0-9]+\z/ } do
-    validates :price, numericality: {only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 }, presence: { message: "can't be blamk" }
+    validates :price, numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 },
+                      presence: { message: "can't be blamk" }
   end
 
   def was_attached?
-    self.image.attached?
+    image.attached?
   end
-
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -17,8 +17,7 @@ class Prefecture < ActiveHash::Base
     { id: 43, name: '長崎県' }, { id: 44, name: '熊本県' }, { id: 45, name: '大分県' },
     { id: 46, name: '宮崎県' }, { id: 47, name: '鹿児島県' }, { id: 48, name: '沖縄県' }
   ]
-  
+
   include ActiveHash::Associations
   has_many :item
-
-  end
+end

--- a/app/models/schedule.rb
+++ b/app/models/schedule.rb
@@ -5,8 +5,7 @@ class Schedule < ActiveHash::Base
     { id: 3, name: '2〜3日で発送' },
     { id: 4, name: '4〜7日で発送' }
   ]
-  
+
   include ActiveHash::Associations
   has_many :item
-
-  end
+end

--- a/app/models/shipping.rb
+++ b/app/models/shipping.rb
@@ -4,8 +4,7 @@ class Shipping < ActiveHash::Base
     { id: 2, name: '着払い（購入者負担）' },
     { id: 3, name: '送料込み（出品者負担）' }
   ]
-  
+
   include ActiveHash::Associations
   has_many :item
-
-  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
 
   validates :nickname, presence: true
 
-  with_options presence: true, format: {with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/} do
+  with_options presence: true, format: { with: /\A[ぁ-んァ-ヶ一-龥々ー]+\z/ } do
     validates :family_name
     validates :first_name
   end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
 
      <% @item.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,66 +4,67 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <%= image_tag @item.image, class: "item-box-img" %>
+      <% if @item.order.present? %>
+        <div class="sold-out">
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping.name %>
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
+    <% if user_signed_in? %>
+      <% if current_user == @item.user %>
+        <% unless @item.order.present? %>
+          <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+          <p class="or-text">or</p>
+          <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <% end %>
+      <% else %>
+        <% unless @item.order.present? %>
+          <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+        <% end %>
+      <% end %>
+    <% end %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.schedule.name %></td>
         </tr>
       </tbody>
     </table>
@@ -102,9 +103,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -5,11 +5,11 @@ FactoryBot.define do
     shipping_id      { 3 }
     prefecture_id    { 10 }
     schedule_id      { 3 }
-    item_name        { "商品名" }
-    explanation      { "商品の説明" }
-    price            { "333" }
+    item_name        { '商品名' }
+    explanation      { '商品の説明' }
+    price            { '333' }
     association :user
-    
+
     after(:build) do |item|
       item.image.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')
     end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :order do
-    
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,10 +4,10 @@ FactoryBot.define do
     email                 { Faker::Internet.free_email }
     password              { '1a' + Faker::Internet.password(min_length: 6) }
     password_confirmation { password }
-    family_name           { "山田" }
-    first_name            { "太郎" }
-    family_name_kana      { "ヤマダ" }
-    first_name_kana       { "タロウ" }
+    family_name           { '山田' }
+    first_name            { '太郎' }
+    family_name_kana      { 'ヤマダ' }
+    first_name_kana       { 'タロウ' }
     birth_day             { Faker::Date.birthday }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -8,25 +8,24 @@ RSpec.describe User, type: :model do
   end
 
   describe 'ユーザー新規登録' do
-
     context '新規登録できる場合' do
-      it "nameとemail、passwordとpassword_confirmation、first_name、family_name、first_name_kana、family_name_kana、birth_dayが存在すれば登録できる" do
+      it 'nameとemail、passwordとpassword_confirmation、first_name、family_name、first_name_kana、family_name_kana、birth_dayが存在すれば登録できる' do
         expect(@user).to be_valid
       end
     end
 
     context '新規登録できない場合' do
-      it "nicknameが空では登録できない" do
+      it 'nicknameが空では登録できない' do
         @user.nickname = ''
         @user.valid?
         expect(@user.errors.full_messages).to include("Nickname can't be blank")
       end
-      it "emailが空では登録できない" do
+      it 'emailが空では登録できない' do
         @user.email = ''
         @user.valid?
         expect(@user.errors.full_messages).to include("Email can't be blank")
       end
-      it "passwordが空では登録できない" do
+      it 'passwordが空では登録できない' do
         @user.password = ''
         @user.valid?
         expect(@user.errors.full_messages).to include("Password can't be blank")
@@ -67,7 +66,7 @@ RSpec.describe User, type: :model do
         another_user.valid?
         expect(another_user.errors.full_messages).to include('Email has already been taken')
       end
-     it 'emailは@を含まないと登録できない' do
+      it 'emailは@を含まないと登録できない' do
         @user.email = 'testmail'
         @user.valid?
         expect(@user.errors.full_messages).to include('Email is invalid')
@@ -120,4 +119,3 @@ RSpec.describe User, type: :model do
     end
   end
 end
-


### PR DESCRIPTION
#What
商品詳細表示の実装をした

#Why
商品の詳細情報をユーザーが確認でき、その後、商品の購入または、出品者であれば編集・削除などのアクションへ導けるようにする。


■ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/211c95ff10dff98199a07fa77313ab79

■ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
→これはローカル環境で不可能ではないかと思い、どのように対応すれば良いか分かりませんでした。

■ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の
実装が済んでいる場合）
→まだ購入機能が実装できておりません。

■ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/98bbf4d7a629e388ceed72d80e52dffa
